### PR TITLE
Add Stale PR Workflow

### DIFF
--- a/.github/workflows/close-stale-pr.yml
+++ b/.github/workflows/close-stale-pr.yml
@@ -1,22 +1,16 @@
-name: Close inactive issues
+name: Close inactive PRs
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "30 1 * * *
 
 jobs:
   close-issues:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
       pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
-          stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: 120
           days-before-pr-close: 14
           stale-pr-label: "stale"

--- a/.github/workflows/close-stale-pr.yml
+++ b/.github/workflows/close-stale-pr.yml
@@ -12,11 +12,14 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-issue-stale: 120
-          days-before-issue-close: 14
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 120 days with no activity."
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
+          days-before-pr-stale: 120
+          days-before-pr-close: 14
+          stale-pr-label: "stale"
+          stale-pr-message: "This pull request is stale because it has been open for 120 days with no activity."
+          close-pr-message: "This pull request was closed because it has been inactive for 14 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-stale-pr.yml
+++ b/.github/workflows/close-stale-pr.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 120
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 120 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-stale-pr.yml
+++ b/.github/workflows/close-stale-pr.yml
@@ -1,10 +1,10 @@
 name: Close inactive PRs
 on:
   schedule:
-    - cron: "30 1 * * *
+    - cron: "30 1 * * *"
 
 jobs:
-  close-issues:
+  close-prs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
This PR adds a .yml file that, after `days-before-pr-stale`, comments under stale issue like a PR to prompt users involved in said issue to resolve it within `days-before-pr-close` days.

Taken almost verbatim from [https://docs.github.com/en/actions/tutorials/manage-your-work/close-inactive-issues](url).